### PR TITLE
Check if custom parent class is present

### DIFF
--- a/lib/acts_as_follower/follower_lib.rb
+++ b/lib/acts_as_follower/follower_lib.rb
@@ -33,7 +33,7 @@ module ActsAsFollower
     end
 
     def parent_classes
-      return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes
+      return DEFAULT_PARENTS unless ActsAsFollower.custom_parent_classes.present?
 
       ActiveSupport::Deprecation.warn("Setting custom parent classes is deprecated and will be removed in future versions.")
       ActsAsFollower.custom_parent_classes + DEFAULT_PARENTS


### PR DESCRIPTION
Deprecation warnings are spamming the test output stating that:
```
DEPRECATION WARNING: Setting custom parent classes is deprecated and will be removed in future versions.
```
However, custom parent classes are initialized to an empty array by default, hence the deprecation warning. Instead check if the custom parent class is blank (present).

See https://github.com/AgileVentures/WebsiteOne/issues/2499 for more info.